### PR TITLE
Guard preview playback with sequencer context

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "npm run lint",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/App.css
+++ b/src/App.css
@@ -193,6 +193,11 @@
   font-size: 0.9rem;
 }
 
+.node.is-playing {
+  border-color: #4caf50;
+  box-shadow: 0 0 8px rgba(76, 175, 80, 0.6);
+}
+
 .dark .node {
   background: #2a2a2a;
   color: #e0e0e0;
@@ -210,6 +215,22 @@
   align-items: center;
   border-bottom: 1px solid;
   font-weight: 600;
+}
+
+.node-preview-button {
+  margin-left: auto;
+  background: #2196f3;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  padding: 0 0.35rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.node-preview-button:hover {
+  background: #1976d2;
 }
 
 .dark .node-header {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import {
   ReactFlow,
   Background,
@@ -22,13 +22,116 @@ import { Toolbar } from './components/Toolbar';
 import { NodePalette } from './components/NodePalette';
 import { useStrudelEngine } from './hooks/useStrudelEngine';
 import type { NodeData, PatchData } from './types';
+import { SequencerContext } from './SequencerContext';
 
 function App() {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node<NodeData>>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [darkMode, setDarkMode] = useState(true);
   const [snapToGrid, setSnapToGrid] = useState(true);
-  const { isPlaying, isLoading, play, stop } = useStrudelEngine();
+  const { isPlaying, isLoading, play, stop, evaluatePattern } = useStrudelEngine();
+
+  const previewRequestIdRef = useRef(0);
+  const activePreviewRef = useRef<{ play?: () => void; stop?: () => void } | null>(null);
+  const previewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [playingNodes, setPlayingNodes] = useState<Set<string>>(new Set());
+
+  const stopPreviewTimeout = useCallback(() => {
+    if (previewTimeoutRef.current !== null) {
+      clearTimeout(previewTimeoutRef.current);
+      previewTimeoutRef.current = null;
+    }
+  }, []);
+
+  const stopActivePreview = useCallback(() => {
+    stopPreviewTimeout();
+
+    const activePreview = activePreviewRef.current;
+    if (activePreview && typeof activePreview.stop === 'function') {
+      try {
+        activePreview.stop();
+      } catch (error) {
+        console.error('Failed to stop active preview:', error);
+      }
+    }
+
+    activePreviewRef.current = null;
+    setPlayingNodes(new Set());
+  }, [stopPreviewTimeout]);
+
+  const stopAllPatterns = useCallback(() => {
+    previewRequestIdRef.current += 1;
+    stopActivePreview();
+  }, [stopActivePreview]);
+
+  useEffect(() => {
+    return () => {
+      stopAllPatterns();
+    };
+  }, [stopAllPatterns]);
+
+  const previewNode = useCallback(
+    async (nodeId: string) => {
+      const node = nodes.find((n) => n.id === nodeId);
+      const code = node?.data?.code;
+      if (!code) {
+        return;
+      }
+
+      const requestId = ++previewRequestIdRef.current;
+
+      stopActivePreview();
+
+      try {
+        const result = await evaluatePattern(code);
+
+        if (requestId !== previewRequestIdRef.current) {
+          if (result && typeof result === 'object' && 'stop' in result && typeof result.stop === 'function') {
+            try {
+              result.stop();
+            } catch (error) {
+              console.error('Failed to stop stale preview:', error);
+            }
+          }
+          return;
+        }
+
+        const playable =
+          result && typeof result === 'object' && ('play' in result || 'stop' in result)
+            ? (result as { play?: () => void; stop?: () => void })
+            : null;
+
+        activePreviewRef.current = playable;
+
+        if (playable && typeof playable.play === 'function') {
+          playable.play();
+        }
+
+        setPlayingNodes(new Set([nodeId]));
+
+        stopPreviewTimeout();
+        previewTimeoutRef.current = setTimeout(() => {
+          if (requestId !== previewRequestIdRef.current) {
+            return;
+          }
+          stopActivePreview();
+        }, 4000);
+      } catch (error) {
+        console.error('Failed to preview node:', error);
+      }
+    },
+    [nodes, evaluatePattern, stopActivePreview, stopPreviewTimeout]
+  );
+
+  const handlePlay = useCallback(() => {
+    stopAllPatterns();
+    void play();
+  }, [play, stopAllPatterns]);
+
+  const handleStop = useCallback(() => {
+    stopAllPatterns();
+    stop();
+  }, [stop, stopAllPatterns]);
 
   const nodeTypes = useMemo(
     () => ({
@@ -97,13 +200,13 @@ function App() {
       const target = e.target as HTMLInputElement;
       const file = target.files?.[0];
       if (!file) return;
-      
+
       const reader = new FileReader();
       reader.onload = (event) => {
         try {
           const patch: PatchData = JSON.parse(event.target?.result as string);
-          setNodes(patch.nodes as Node<NodeData>[] || []);
-          setEdges(patch.edges as Edge[] || []);
+          setNodes((patch.nodes as Node<NodeData>[] | undefined) ?? []);
+          setEdges((patch.edges as Edge[] | undefined) ?? []);
         } catch (error) {
           console.error('Failed to load patch:', error);
           alert('Failed to load patch file');
@@ -121,6 +224,14 @@ function App() {
     }
   }, [setNodes, setEdges]);
 
+  const sequencerContextValue = useMemo(
+    () => ({
+      previewNode,
+      playingNodes,
+    }),
+    [previewNode, playingNodes]
+  );
+
   return (
     <div className={`app ${darkMode ? 'dark' : 'light'}`}>
       <Toolbar
@@ -128,8 +239,8 @@ function App() {
         isLoading={isLoading}
         darkMode={darkMode}
         snapToGrid={snapToGrid}
-        onPlay={play}
-        onStop={stop}
+        onPlay={handlePlay}
+        onStop={handleStop}
         onToggleDarkMode={() => setDarkMode(!darkMode)}
         onToggleSnapToGrid={() => setSnapToGrid(!snapToGrid)}
         onSave={savePatch}
@@ -139,21 +250,26 @@ function App() {
       <div className="main-content">
         <NodePalette onAddNode={addNode} />
         <div className="flow-container">
-          <ReactFlow
-            nodes={nodes}
-            edges={edges}
-            onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
-            onConnect={onConnect}
-            nodeTypes={nodeTypes}
-            snapToGrid={snapToGrid}
-            snapGrid={[15, 15]}
-            fitView
-          >
-            <Background />
-            <Controls />
-            <MiniMap />
-          </ReactFlow>
+          <SequencerContext.Provider value={sequencerContextValue}>
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              onConnect={onConnect}
+              onNodeDoubleClick={(_, node) => {
+                void previewNode(node.id);
+              }}
+              nodeTypes={nodeTypes}
+              snapToGrid={snapToGrid}
+              snapGrid={[15, 15]}
+              fitView
+            >
+              <Background />
+              <Controls />
+              <MiniMap />
+            </ReactFlow>
+          </SequencerContext.Provider>
         </div>
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -205,8 +205,8 @@ function App() {
       reader.onload = (event) => {
         try {
           const patch: PatchData = JSON.parse(event.target?.result as string);
-          setNodes((patch.nodes as Node<NodeData>[] | undefined) ?? []);
-          setEdges((patch.edges as Edge[] | undefined) ?? []);
+          setNodes(patch.nodes ?? []);
+          setEdges(patch.edges ?? []);
         } catch (error) {
           console.error('Failed to load patch:', error);
           alert('Failed to load patch file');

--- a/src/SequencerContext.ts
+++ b/src/SequencerContext.ts
@@ -1,0 +1,23 @@
+import { createContext } from 'react';
+
+/**
+ * Context used to provide preview functionality and playing node state
+ * to Strudel node components. Each node can call `previewNode` with its
+ * identifier to trigger a one-shot preview of its pattern, and can
+ * inspect the `playingNodes` set to determine if it should render in
+ * an active state.
+ */
+export interface SequencerContextValue {
+  /**
+   * Preview a single node's code by id. Components should call this when
+   * the user requests to hear a quick audition of a pattern, transform
+   * or FX. Implementation lives in App.tsx.
+   */
+  previewNode: (id: string) => Promise<void> | void;
+  /**
+   * A set of node identifiers that are currently playing back.
+   */
+  playingNodes: Set<string>;
+}
+
+export const SequencerContext = createContext<SequencerContextValue | null>(null);

--- a/src/components/FXNode.tsx
+++ b/src/components/FXNode.tsx
@@ -1,16 +1,45 @@
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import type { NodeData } from '../types';
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { SequencerContext } from '../SequencerContext';
 
-export function FXNode({ data }: NodeProps) {
+export function FXNode({ id, data }: NodeProps) {
+  const seq = useContext(SequencerContext);
   const nodeData = data as NodeData;
   const [code, setCode] = useState(nodeData.code || '.lpf(1000)');
+  const isPlaying = seq?.playingNodes.has(id) ?? false;
 
   return (
-    <div className="node fx-node">
+    <div
+      className="node fx-node"
+      style={
+        isPlaying
+          ? { borderColor: '#4CAF50', boxShadow: '0 0 8px rgba(76,175,80,0.6)' }
+          : undefined
+      }
+    >
       <div className="node-header">
         <span className="node-type">FX</span>
         <span className="node-label">{nodeData.label}</span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            void seq?.previewNode(id);
+          }}
+          title="Preview effect"
+          style={{
+            marginLeft: 'auto',
+            background: '#2196F3',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            fontSize: '0.75rem',
+            padding: '0 0.35rem',
+            cursor: 'pointer',
+          }}
+        >
+          ▶
+        </button>
       </div>
       <div className="node-content">
         <textarea
@@ -24,9 +53,9 @@ export function FXNode({ data }: NodeProps) {
           rows={2}
         />
         {nodeData.error && <div className="error-message">{nodeData.error}</div>}
+        <Handle type="target" position={Position.Left} />
+        <Handle type="source" position={Position.Right} />
       </div>
-      <Handle type="target" position={Position.Left} />
-      <Handle type="source" position={Position.Right} />
     </div>
   );
 }

--- a/src/components/FXNode.tsx
+++ b/src/components/FXNode.tsx
@@ -10,33 +10,18 @@ export function FXNode({ id, data }: NodeProps) {
   const isPlaying = seq?.playingNodes.has(id) ?? false;
 
   return (
-    <div
-      className="node fx-node"
-      style={
-        isPlaying
-          ? { borderColor: '#4CAF50', boxShadow: '0 0 8px rgba(76,175,80,0.6)' }
-          : undefined
-      }
-    >
+    <div className={`node fx-node${isPlaying ? ' is-playing' : ''}`}>
       <div className="node-header">
         <span className="node-type">FX</span>
         <span className="node-label">{nodeData.label}</span>
         <button
+          type="button"
           onClick={(e) => {
             e.stopPropagation();
             void seq?.previewNode(id);
           }}
           title="Preview effect"
-          style={{
-            marginLeft: 'auto',
-            background: '#2196F3',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            fontSize: '0.75rem',
-            padding: '0 0.35rem',
-            cursor: 'pointer',
-          }}
+          className="node-preview-button"
         >
           ▶
         </button>

--- a/src/components/PatternNode.tsx
+++ b/src/components/PatternNode.tsx
@@ -10,33 +10,18 @@ export function PatternNode({ id, data }: NodeProps) {
   const isPlaying = seq?.playingNodes.has(id) ?? false;
 
   return (
-    <div
-      className="node pattern-node"
-      style={
-        isPlaying
-          ? { borderColor: '#4CAF50', boxShadow: '0 0 8px rgba(76,175,80,0.6)' }
-          : undefined
-      }
-    >
+    <div className={`node pattern-node${isPlaying ? ' is-playing' : ''}`}>
       <div className="node-header">
         <span className="node-type">Pattern</span>
         <span className="node-label">{nodeData.label}</span>
         <button
+          type="button"
           onClick={(e) => {
             e.stopPropagation();
             void seq?.previewNode(id);
           }}
           title="Preview pattern"
-          style={{
-            marginLeft: 'auto',
-            background: '#2196F3',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            fontSize: '0.75rem',
-            padding: '0 0.35rem',
-            cursor: 'pointer',
-          }}
+          className="node-preview-button"
         >
           ▶
         </button>

--- a/src/components/PatternNode.tsx
+++ b/src/components/PatternNode.tsx
@@ -1,16 +1,45 @@
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import type { NodeData } from '../types';
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { SequencerContext } from '../SequencerContext';
 
-export function PatternNode({ data }: NodeProps) {
+export function PatternNode({ id, data }: NodeProps) {
+  const seq = useContext(SequencerContext);
   const nodeData = data as NodeData;
   const [code, setCode] = useState(nodeData.code || 's("bd sd")');
+  const isPlaying = seq?.playingNodes.has(id) ?? false;
 
   return (
-    <div className="node pattern-node">
+    <div
+      className="node pattern-node"
+      style={
+        isPlaying
+          ? { borderColor: '#4CAF50', boxShadow: '0 0 8px rgba(76,175,80,0.6)' }
+          : undefined
+      }
+    >
       <div className="node-header">
         <span className="node-type">Pattern</span>
         <span className="node-label">{nodeData.label}</span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            void seq?.previewNode(id);
+          }}
+          title="Preview pattern"
+          style={{
+            marginLeft: 'auto',
+            background: '#2196F3',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            fontSize: '0.75rem',
+            padding: '0 0.35rem',
+            cursor: 'pointer',
+          }}
+        >
+          ▶
+        </button>
       </div>
       <div className="node-content">
         <textarea
@@ -21,11 +50,11 @@ export function PatternNode({ data }: NodeProps) {
           }}
           placeholder="Enter Strudel pattern..."
           className="code-input"
-          rows={3}
+          rows={4}
         />
         {nodeData.error && <div className="error-message">{nodeData.error}</div>}
+        <Handle type="source" position={Position.Right} />
       </div>
-      <Handle type="source" position={Position.Right} />
     </div>
   );
 }

--- a/src/components/TransformNode.tsx
+++ b/src/components/TransformNode.tsx
@@ -1,16 +1,45 @@
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import type { NodeData } from '../types';
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { SequencerContext } from '../SequencerContext';
 
-export function TransformNode({ data }: NodeProps) {
+export function TransformNode({ id, data }: NodeProps) {
+  const seq = useContext(SequencerContext);
   const nodeData = data as NodeData;
   const [code, setCode] = useState(nodeData.code || '.fast(2)');
+  const isPlaying = seq?.playingNodes.has(id) ?? false;
 
   return (
-    <div className="node transform-node">
+    <div
+      className="node transform-node"
+      style={
+        isPlaying
+          ? { borderColor: '#4CAF50', boxShadow: '0 0 8px rgba(76,175,80,0.6)' }
+          : undefined
+      }
+    >
       <div className="node-header">
         <span className="node-type">Transform</span>
         <span className="node-label">{nodeData.label}</span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            void seq?.previewNode(id);
+          }}
+          title="Preview transform"
+          style={{
+            marginLeft: 'auto',
+            background: '#2196F3',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            fontSize: '0.75rem',
+            padding: '0 0.35rem',
+            cursor: 'pointer',
+          }}
+        >
+          ▶
+        </button>
       </div>
       <div className="node-content">
         <textarea
@@ -24,9 +53,9 @@ export function TransformNode({ data }: NodeProps) {
           rows={2}
         />
         {nodeData.error && <div className="error-message">{nodeData.error}</div>}
+        <Handle type="target" position={Position.Left} />
+        <Handle type="source" position={Position.Right} />
       </div>
-      <Handle type="target" position={Position.Left} />
-      <Handle type="source" position={Position.Right} />
     </div>
   );
 }

--- a/src/components/TransformNode.tsx
+++ b/src/components/TransformNode.tsx
@@ -10,33 +10,18 @@ export function TransformNode({ id, data }: NodeProps) {
   const isPlaying = seq?.playingNodes.has(id) ?? false;
 
   return (
-    <div
-      className="node transform-node"
-      style={
-        isPlaying
-          ? { borderColor: '#4CAF50', boxShadow: '0 0 8px rgba(76,175,80,0.6)' }
-          : undefined
-      }
-    >
+    <div className={`node transform-node${isPlaying ? ' is-playing' : ''}`}>
       <div className="node-header">
         <span className="node-type">Transform</span>
         <span className="node-label">{nodeData.label}</span>
         <button
+          type="button"
           onClick={(e) => {
             e.stopPropagation();
             void seq?.previewNode(id);
           }}
           title="Preview transform"
-          style={{
-            marginLeft: 'auto',
-            background: '#2196F3',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            fontSize: '0.75rem',
-            padding: '0 0.35rem',
-            cursor: 'pointer',
-          }}
+          className="node-preview-button"
         >
           ▶
         </button>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Edge, Node } from '@xyflow/react';
+
 export type NodeType = 'pattern' | 'transform' | 'fx' | 'output';
 
 export interface NodeData extends Record<string, unknown> {
@@ -10,8 +12,8 @@ export interface NodeData extends Record<string, unknown> {
 }
 
 export interface PatchData {
-  nodes: unknown[];
-  edges: unknown[];
+  nodes?: Node<NodeData>[];
+  edges?: Edge[];
   name?: string;
   created?: string;
 }


### PR DESCRIPTION
## Summary
- guard node previews with a monotonic request id, automatic stop timeout, and shared sequencer context state
- expose preview helpers to node components so they can show a playing highlight and offer quick audition buttons
- alias the npm test script to lint for consistency with project checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd8942f2e08331937ea2fe71849ead