### PR TITLE
Add execution controller with run queue and live-mode hot-reload

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -424,3 +424,24 @@ body {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
 }
+
+.run-queue-log {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  width: min(360px, 90vw);
+  max-height: 220px;
+  overflow: auto;
+  padding: 0.75rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--panel-border);
+  background: var(--panel-bg);
+  backdrop-filter: blur(10px);
+  font-size: 0.8rem;
+  z-index: 4;
+}
+
+.run-queue-log ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.1rem;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,18 +25,39 @@ import type { NodeData, PatchData } from './types';
 import { SequencerContext } from './SequencerContext';
 import { createStaleRequestGuard } from './utils/staleRequestGuard';
 import { compileStrudelPatch } from './utils/strudelGraph';
+import { createRunRequest, ExecutionController, type RunResult } from './execution/executionController';
 
 function App() {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node<NodeData>>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [darkMode, setDarkMode] = useState(true);
   const [snapToGrid, setSnapToGrid] = useState(true);
+  const [liveEnabled, setLiveEnabled] = useState(false);
+  const [runLog, setRunLog] = useState<RunResult[]>([]);
   const { isPlaying, isLoading, stop, evaluatePattern } = useStrudelEngine();
 
   const previewGuardRef = useRef(createStaleRequestGuard());
   const activePreviewRef = useRef<{ play?: () => void; stop?: () => void } | null>(null);
   const previewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [playingNodes, setPlayingNodes] = useState<Set<string>>(new Set());
+
+  const executionControllerRef = useRef<ExecutionController | null>(null);
+
+  useEffect(() => {
+    executionControllerRef.current = new ExecutionController({
+      evaluate: (code) => evaluatePattern(code, { markPlaying: true }),
+      stop,
+      onRunResult: (result) => {
+        setRunLog((current) => [...current.slice(-9), result]);
+      },
+    });
+
+    return () => {
+      executionControllerRef.current?.cancelCurrent();
+      executionControllerRef.current?.clearQueue();
+      executionControllerRef.current = null;
+    };
+  }, [evaluatePattern, stop]);
 
   const stopPreviewTimeout = useCallback(() => {
     if (previewTimeoutRef.current !== null) {
@@ -75,6 +96,36 @@ function App() {
   const compiledPatch = useMemo(() => compileStrudelPatch(nodes, edges), [nodes, edges]);
   const compiledExpressions = compiledPatch.expressions;
   const compiledPatchCode = compiledPatch.patchCode;
+
+  const settingsHash = useMemo(() => {
+    return JSON.stringify({
+      nodes: nodes.map((node) => ({ id: node.id, data: node.data, position: node.position, type: node.type })),
+      edges: edges.map((edge) => ({ id: edge.id, source: edge.source, target: edge.target })),
+    });
+  }, [nodes, edges]);
+
+  useEffect(() => {
+    if (!liveEnabled || !isPlaying || !compiledPatchCode) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      const controller = executionControllerRef.current;
+      if (!controller) {
+        return;
+      }
+
+      controller.replaceLatest(
+        createRunRequest(compiledPatchCode, 'live', {
+          label: 'Live hot reload',
+          settingsHash,
+        })
+      );
+    }, 250);
+
+    return () => clearTimeout(timeout);
+  }, [liveEnabled, isPlaying, compiledPatchCode, settingsHash]);
+
   const previewNode = useCallback(
     async (nodeId: string) => {
       const node = nodes.find((n) => n.id === nodeId);
@@ -150,13 +201,19 @@ function App() {
       console.warn('No playable pattern found in the current patch.');
       return;
     }
-    void evaluatePattern(code).catch((error) => {
-      console.error('Failed to evaluate patch:', error);
-    });
-  }, [evaluatePattern, compiledPatchCode, stopAllPatterns]);
+
+    executionControllerRef.current?.enqueue(
+      createRunRequest(code, 'batch', {
+        label: 'Play patch',
+        settingsHash,
+      })
+    );
+  }, [compiledPatchCode, settingsHash, stopAllPatterns]);
 
   const handleStop = useCallback(() => {
     stopAllPatterns();
+    executionControllerRef.current?.cancelCurrent();
+    executionControllerRef.current?.clearQueue();
     stop();
   }, [stop, stopAllPatterns]);
 
@@ -272,10 +329,12 @@ function App() {
         isLoading={isLoading}
         darkMode={darkMode}
         snapToGrid={snapToGrid}
+        liveEnabled={liveEnabled}
         onPlay={handlePlay}
         onStop={handleStop}
         onToggleDarkMode={() => setDarkMode(!darkMode)}
         onToggleSnapToGrid={() => setSnapToGrid(!snapToGrid)}
+        onToggleLiveMode={() => setLiveEnabled(!liveEnabled)}
         onSave={savePatch}
         onLoad={loadPatch}
         onClear={clearCanvas}
@@ -305,6 +364,16 @@ function App() {
             </ReactFlow>
           </SequencerContext.Provider>
         </div>
+      </div>
+      <div className="run-queue-log" aria-live="polite">
+        <strong>Run queue log</strong>
+        <ul>
+          {runLog.map((result) => (
+            <li key={`${result.id}-${result.finishedAt}`}>
+              {result.mode} · {result.status} · {result.label ?? result.id}
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/src/components/Toolbar.test.tsx
+++ b/src/components/Toolbar.test.tsx
@@ -15,10 +15,12 @@ function createProps(overrides: Partial<ToolbarProps> = {}): ToolbarProps {
     isLoading: false,
     darkMode: false,
     snapToGrid: true,
+    liveEnabled: false,
     onPlay: vi.fn(),
     onStop: vi.fn(),
     onToggleDarkMode: vi.fn(),
     onToggleSnapToGrid: vi.fn(),
+    onToggleLiveMode: vi.fn(),
     onSave: vi.fn(),
     onLoad: vi.fn(),
     onClear: vi.fn(),
@@ -61,12 +63,14 @@ describe('Toolbar', () => {
     const props = createProps();
     render(<Toolbar {...props} />);
 
+    fireEvent.click(screen.getByLabelText('Live Mode'));
     fireEvent.click(screen.getByLabelText('Snap to Grid'));
     fireEvent.click(screen.getByLabelText('Dark Mode'));
     fireEvent.click(screen.getByRole('button', { name: /Save Patch/ }));
     fireEvent.click(screen.getByRole('button', { name: /Load Patch/ }));
     fireEvent.click(screen.getByRole('button', { name: /Clear/ }));
 
+    expect(props.onToggleLiveMode).toHaveBeenCalledTimes(1);
     expect(props.onToggleSnapToGrid).toHaveBeenCalledTimes(1);
     expect(props.onToggleDarkMode).toHaveBeenCalledTimes(1);
     expect(props.onSave).toHaveBeenCalledTimes(1);

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -10,6 +10,8 @@ interface ToolbarProps {
   onSave: () => void;
   onLoad: () => void;
   onClear: () => void;
+  liveEnabled: boolean;
+  onToggleLiveMode: () => void;
 }
 
 export function Toolbar({
@@ -24,6 +26,8 @@ export function Toolbar({
   onSave,
   onLoad,
   onClear,
+  liveEnabled,
+  onToggleLiveMode,
 }: ToolbarProps) {
   return (
     <div className="toolbar">
@@ -54,6 +58,14 @@ export function Toolbar({
       </div>
 
       <div className="toolbar-section">
+        <label className="toggle">
+          <input
+            type="checkbox"
+            checked={liveEnabled}
+            onChange={onToggleLiveMode}
+          />
+          <span>Live Mode</span>
+        </label>
         <label className="toggle">
           <input
             type="checkbox"

--- a/src/execution/executionController.test.ts
+++ b/src/execution/executionController.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ExecutionController, type RunResult } from './executionController';
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('ExecutionController', () => {
+  it('runs queued requests serially with deterministic stop/evaluate order', async () => {
+    const sequence: string[] = [];
+    const evaluate = vi.fn(async (code: string) => {
+      sequence.push(`eval:${code}`);
+    });
+    const stop = vi.fn(() => {
+      sequence.push('stop');
+    });
+
+    const controller = new ExecutionController({ evaluate, stop });
+
+    controller.enqueue({ id: '1', code: 's("bd")', mode: 'batch', requestedAt: 1 });
+    controller.enqueue({ id: '2', code: 's("sd")', mode: 'batch', requestedAt: 2 });
+
+    await flushPromises();
+
+    expect(sequence).toEqual(['stop', 'eval:s("bd")', 'stop', 'eval:s("sd")']);
+  });
+
+  it('supports replaceLatest semantics by keeping only the newest queued run', async () => {
+    let releaseFirst: (() => void) | undefined;
+    const evaluate = vi.fn(
+      (code: string) =>
+        new Promise<void>((resolve) => {
+          if (code === 'first') {
+            releaseFirst = resolve;
+            return;
+          }
+          resolve();
+        })
+    );
+    const stop = vi.fn();
+
+    const results: RunResult[] = [];
+    const controller = new ExecutionController({ evaluate, stop, onRunResult: (result) => results.push(result) });
+
+    controller.enqueue({ id: '1', code: 'first', mode: 'batch', requestedAt: 1 });
+    controller.enqueue({ id: '2', code: 'stale', mode: 'batch', requestedAt: 2 });
+    controller.replaceLatest({ id: '3', code: 'latest', mode: 'batch', requestedAt: 3 });
+
+    releaseFirst?.();
+    await flushPromises();
+
+    expect(evaluate).toHaveBeenCalledTimes(2);
+    expect(evaluate).toHaveBeenNthCalledWith(1, 'first');
+    expect(evaluate).toHaveBeenNthCalledWith(2, 'latest');
+    expect(results.map((result) => result.id)).toEqual(['1', '3']);
+  });
+
+  it('can cancel the current run', async () => {
+    let releaseRun: (() => void) | undefined;
+    const evaluate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRun = resolve;
+        })
+    );
+    const stop = vi.fn();
+
+    const results: RunResult[] = [];
+    const controller = new ExecutionController({ evaluate, stop, onRunResult: (result) => results.push(result) });
+
+    controller.enqueue({ id: '1', code: 'long', mode: 'batch', requestedAt: 1 });
+    await Promise.resolve();
+
+    controller.cancelCurrent();
+    releaseRun?.();
+    await flushPromises();
+
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(results.at(-1)?.status).toBe('cancelled');
+  });
+
+  it('skips duplicate runs based on code/settings hash', async () => {
+    const evaluate = vi.fn(async () => undefined);
+    const stop = vi.fn();
+
+    const results: RunResult[] = [];
+    const controller = new ExecutionController({ evaluate, stop, onRunResult: (result) => results.push(result) });
+
+    const request = { id: '1', code: 's("bd")', mode: 'live' as const, requestedAt: 1, settingsHash: 'x' };
+    controller.enqueue(request);
+    controller.enqueue({ ...request, id: '2', requestedAt: 2 });
+
+    await flushPromises();
+
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(results[0]?.status).toBe('completed');
+    expect(results[1]?.status).toBe('skipped');
+  });
+});

--- a/src/execution/executionController.ts
+++ b/src/execution/executionController.ts
@@ -1,0 +1,184 @@
+export type RunMode = 'batch' | 'live';
+
+export interface RunRequest {
+  id: string;
+  code: string;
+  requestedAt: number;
+  mode: RunMode;
+  settingsHash?: string;
+  label?: string;
+}
+
+export type RunStatus = 'completed' | 'failed' | 'cancelled' | 'skipped';
+
+export interface RunResult {
+  id: string;
+  status: RunStatus;
+  startedAt: number;
+  finishedAt: number;
+  mode: RunMode;
+  label?: string;
+  error?: unknown;
+}
+
+export interface ExecutionControllerOptions {
+  evaluate: (code: string) => Promise<unknown>;
+  stop: () => void;
+  now?: () => number;
+  onRunResult?: (result: RunResult) => void;
+}
+
+const createRequestHash = (request: RunRequest) => `${request.code}::${request.settingsHash ?? ''}`;
+
+export class ExecutionController {
+  private readonly evaluate: (code: string) => Promise<unknown>;
+  private readonly stop: () => void;
+  private readonly now: () => number;
+  private readonly onRunResult?: (result: RunResult) => void;
+
+  private queue: RunRequest[] = [];
+  private isProcessing = false;
+  private runToken = 0;
+  private currentRunToken: number | null = null;
+  private lastSuccessfulHash: string | null = null;
+
+  constructor(options: ExecutionControllerOptions) {
+    this.evaluate = options.evaluate;
+    this.stop = options.stop;
+    this.now = options.now ?? Date.now;
+    this.onRunResult = options.onRunResult;
+  }
+
+  enqueue(request: RunRequest) {
+    this.queue.push(request);
+    this.processQueue();
+  }
+
+  replaceLatest(request: RunRequest) {
+    this.queue = [request];
+    this.processQueue();
+  }
+
+  clearQueue() {
+    this.queue = [];
+  }
+
+  cancelCurrent() {
+    if (this.currentRunToken !== null) {
+      this.runToken += 1;
+      this.currentRunToken = null;
+      this.stop();
+    }
+  }
+
+  getQueueSnapshot() {
+    return [...this.queue];
+  }
+
+  private emit(result: RunResult) {
+    this.onRunResult?.(result);
+  }
+
+  private async processQueue() {
+    if (this.isProcessing) {
+      return;
+    }
+
+    this.isProcessing = true;
+
+    while (this.queue.length > 0) {
+      const next = this.queue.shift();
+      if (!next) {
+        continue;
+      }
+
+      const hash = createRequestHash(next);
+      const startedAt = this.now();
+
+      if (hash === this.lastSuccessfulHash) {
+        this.emit({
+          id: next.id,
+          status: 'skipped',
+          mode: next.mode,
+          label: next.label,
+          startedAt,
+          finishedAt: this.now(),
+        });
+        continue;
+      }
+
+      const token = this.runToken + 1;
+      this.runToken = token;
+      this.currentRunToken = token;
+
+      try {
+        // Ensure deterministic playback transitions.
+        this.stop();
+        await this.evaluate(next.code);
+
+        if (this.currentRunToken !== token) {
+          this.emit({
+            id: next.id,
+            status: 'cancelled',
+            mode: next.mode,
+            label: next.label,
+            startedAt,
+            finishedAt: this.now(),
+          });
+          continue;
+        }
+
+        this.lastSuccessfulHash = hash;
+        this.emit({
+          id: next.id,
+          status: 'completed',
+          mode: next.mode,
+          label: next.label,
+          startedAt,
+          finishedAt: this.now(),
+        });
+      } catch (error) {
+        if (this.currentRunToken !== token) {
+          this.emit({
+            id: next.id,
+            status: 'cancelled',
+            mode: next.mode,
+            label: next.label,
+            startedAt,
+            finishedAt: this.now(),
+          });
+          continue;
+        }
+
+        this.emit({
+          id: next.id,
+          status: 'failed',
+          mode: next.mode,
+          label: next.label,
+          startedAt,
+          finishedAt: this.now(),
+          error,
+        });
+      } finally {
+        if (this.currentRunToken === token) {
+          this.currentRunToken = null;
+        }
+      }
+    }
+
+    this.isProcessing = false;
+  }
+}
+
+export const createRunRequest = (
+  code: string,
+  mode: RunMode,
+  partial: Partial<Pick<RunRequest, 'label' | 'settingsHash'>> = {}
+): RunRequest => ({
+  id: `run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  code,
+  mode,
+  requestedAt: Date.now(),
+  label: partial.label,
+  settingsHash: partial.settingsHash,
+});


### PR DESCRIPTION
### Motivation

- Centralize runtime orchestration so graph compilation/evaluation is decoupled from React and Strudel initialization and to avoid concurrent REPL evaluations.
- Provide deterministic stop-before-evaluate sequencing and sensible semantics for rapid edits (replace-latest, cancel, and dedupe) to support a browser-style live mode.​
- Keep evaluation inside the existing engine boundary while adding a runtime layer that owns run lifecycle and queuing.

### Description

- Add a new `ExecutionController` in `src/execution/executionController.ts` with `RunRequest`/`RunResult` types and APIs: `enqueue`, `replaceLatest`, `clearQueue`, `cancelCurrent`, and hash-based duplicate skipping.
- Wire the controller into `src/App.tsx` so `Play` enqueues runs, `Stop` cancels/clears the queue, and a debounced live-mode path issues `replaceLatest` hot-reload runs while playback is active using a `settingsHash` dedupe key.
- Expose a new Live Mode toggle through `src/components/Toolbar.tsx` and add a small `run-queue-log` UI panel plus styles in `src/App.css` to surface recent run statuses.
- Add unit tests in `src/execution/executionController.test.ts` covering serial execution, `replaceLatest`, cancellation, and dedupe behavior, and update toolbar tests for the Live Mode control.

### Testing

- Ran the test suite with `npm test -- --run` and all tests passed (7 test files, 29 tests total) ✅.
- Ran linting with `npm run lint` and it completed successfully ✅.
- Built the production bundle with `npm run build` and the build completed successfully (Vite build) ✅.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69954d19132c8331848261fde71130cd)